### PR TITLE
fix "ARGS_XXX" compatibility

### DIFF
--- a/src/nkf.c
+++ b/src/nkf.c
@@ -508,9 +508,9 @@ mrb_mruby_nkf_gem_init(mrb_state *mrb)
      mrb_nkf = mrb_define_module(mrb, "NKF");
 
      mrb_define_module_function(mrb, mrb_nkf, "nkf", mrb_nkf_convert, 
-				ARGS_REQ(2));
+				MRB_ARGS_REQ(2));
      mrb_define_module_function(mrb, mrb_nkf, "guess", mrb_nkf_guess,
-				ARGS_REQ(1));
+				MRB_ARGS_REQ(1));
 
      mrb_define_const(mrb, mrb_nkf, "AUTO",       mrb_fixnum_value(_AUTO));
      mrb_define_const(mrb, mrb_nkf, "NOCONV",     mrb_fixnum_value(_NOCONV));


### PR DESCRIPTION
"ARGS_XXX" was defined by deprecated.h .
deprecated.h was added "5c88c65a11287aa52bc0a606ce96a316036aa94c" in 2013.
but "e88e7dc8db4ff129de6698727fd87904b67ed0e0" was removed from deprecated.h .
so,I rename "ARGS_REQ" to "MRB_ARGS_REQ".
